### PR TITLE
Fixed PR comments

### DIFF
--- a/addon/styles/_frost-detail-subtab.scss
+++ b/addon/styles/_frost-detail-subtab.scss
@@ -3,7 +3,10 @@ $frost-detail-tab-active-text: $frost-color-grey-1;
 $frost-detail-tab-inactive: $frost-color-grey-5;
 
 .frost-detail-subtab {
+  display: flex;
   position: relative;
+  flex-direction: row;
+  justify-content: center;
   width: 100%;
   margin-top: 10px;
 
@@ -17,6 +20,7 @@ $frost-detail-tab-inactive: $frost-color-grey-5;
     display: flex;
     flex-direction: column;
     align-items: center;
+    margin-right: 10px;
 
     &:hover {
       cursor: pointer;
@@ -52,7 +56,7 @@ $frost-detail-tab-inactive: $frost-color-grey-5;
   &.selected:after {
     content: " ";
     position: absolute;
-    right: -10px;
+    right: 0;
   	top: 22px;
   	z-index: 1;
     height: 0;

--- a/addon/styles/_frost-detail-subtabs.scss
+++ b/addon/styles/_frost-detail-subtabs.scss
@@ -6,9 +6,12 @@ $frost-detail-tab-inactive: $frost-color-grey-5;
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 120px;
-  margin: 10px 0 ;
-  padding: 0 10px 0 20px;
-  overflow-y: scroll;
-  direction: rtl;
+  width: 110px;
+  margin: 10px 0 10px 20px;
+
+  .frost-scroll {
+    .ps-scrollbar-y-rail {
+      left: -8px;
+    }
+  }
 }

--- a/addon/templates/components/frost-detail-subtabs.hbs
+++ b/addon/templates/components/frost-detail-subtabs.hbs
@@ -1,4 +1,11 @@
 {{!-- <div class='{{css}}-subtabs'> --}}
+{{#frost-scroll
+  class='full'
+  hook=(concat hookPrefix '-scroll')
+  psOptions=(hash
+    suppressScrollX=true
+  )
+}}
   {{#each _subtabs key='id' as |tab|}}
     {{~ frost-detail-subtab
       hook=(concat hookPrefix '-subtab-' tab.id)
@@ -7,4 +14,5 @@
       onSelect=onSelect
     ~}}
   {{/each}}
+{{/frost-scroll}}
 {{!-- </div> --}}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Did the following modifications to the original implementation:
1) I reduced the margins to 10px on top and bottom to align with the content top and bottom
2) I moved the margin left on the container in the selector because the scroll was hiding 10px of the < so we were seeing only half of the <

# CHANGELOG
* **Fixed** scrolling of subtabs